### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.0...horfimbor-eventsource-derive-v0.1.1) - 2024-03-06
+
+### Other
+- release ([#24](https://github.com/horfimbor/horfimbor-engine/pull/24))
+
 ## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-eventsource-derive-v0.1.0) - 2024-03-06
 
 ### Other

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.1.0...horfimbor-eventsource-v0.1.1) - 2024-03-06
+
+### Other
+- release ([#24](https://github.com/horfimbor/horfimbor-engine/pull/24))
+
 ## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-eventsource-v0.1.0) - 2024-03-06
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -16,7 +16,7 @@ serde_json = "1.0"
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tokio = "1.26"
 thiserror = "1.0"
-horfimbor-eventsource-derive = { version = "0.1.0", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.1", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.24", features = ["tokio-rustls-comp"], optional = true }
 chrono = "0.4"
 


### PR DESCRIPTION
## 🤖 New release
* `horfimbor-eventsource`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `horfimbor-eventsource-derive`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource`
<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.1.0...horfimbor-eventsource-v0.1.1) - 2024-03-06

### Other
- release ([#24](https://github.com/horfimbor/horfimbor-engine/pull/24))
</blockquote>

## `horfimbor-eventsource-derive`
<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.0...horfimbor-eventsource-derive-v0.1.1) - 2024-03-06

### Other
- release ([#24](https://github.com/horfimbor/horfimbor-engine/pull/24))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).