### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.2...horfimbor-eventsource-derive-v0.1.3) - 2024-03-17
+
+### Added
+- add a stronger clippy ([#31](https://github.com/horfimbor/horfimbor-engine/pull/31))
+
 ## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.1...horfimbor-eventsource-derive-v0.1.2) - 2024-03-06
 
 ### Other

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.1.2...horfimbor-eventsource-v0.2.0) - 2024-03-17
+
+### Added
+- add a stronger clippy ([#31](https://github.com/horfimbor/horfimbor-engine/pull/31))
+
 ## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.1.1...horfimbor-eventsource-v0.1.2) - 2024-03-06
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tokio = "1.26"
 thiserror = "1.0"
-horfimbor-eventsource-derive = { version = "0.1.2", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.3", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.25", features = ["tokio-rustls-comp"], optional = true }
 chrono = "0.4"
 


### PR DESCRIPTION
## 🤖 New release
* `horfimbor-eventsource`: 0.1.2 -> 0.2.0 (⚠️ API breaking changes)
* `horfimbor-eventsource-derive`: 0.1.2 -> 0.1.3

### ⚠️ `horfimbor-eventsource` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/enum_missing.ron

Failed in:
  enum horfimbor_eventsource::metadata::MetadataError, previously in file /tmp/.tmpm3iwNH/horfimbor-eventsource/src/metadata.rs:128
  enum horfimbor_eventsource::cache_db::CacheDbError, previously in file /tmp/.tmpm3iwNH/horfimbor-eventsource/src/cache_db/mod.rs:37

--- failure inherent_method_must_use_added: inherent method #[must_use] added ---

Description:
An inherent method is now #[must_use]. Downstream crates that did not use its return value will get a compiler lint.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_must_use_added.ron

Failed in:
  method horfimbor_eventsource::model_key::ModelKey::new in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/model_key.rs:13
  method horfimbor_eventsource::model_key::ModelKey::format in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/model_key.rs:23
  method horfimbor_eventsource::metadata::Metadata::correlation_id in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/metadata.rs:23
  method horfimbor_eventsource::metadata::Metadata::causation_id in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/metadata.rs:28
  method horfimbor_eventsource::metadata::Metadata::id in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/metadata.rs:36
  method horfimbor_eventsource::metadata::Metadata::new in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/metadata.rs:41
  method horfimbor_eventsource::metadata::Metadata::is_event in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/metadata.rs:56
  method horfimbor_eventsource::cache_db::NoCache::new in /tmp/.tmpRklcqf/horfimbor-engine/horfimbor-eventsource/src/cache_db/mod.rs:71

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_missing.ron

Failed in:
  struct horfimbor_eventsource::metadata::EventWithMetadata, previously in file /tmp/.tmpm3iwNH/horfimbor-eventsource/src/metadata.rs:49
  struct horfimbor_eventsource::cache_db::redis::RedisStateDb, previously in file /tmp/.tmpm3iwNH/horfimbor-eventsource/src/cache_db/redis.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource`
<blockquote>

## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.1.2...horfimbor-eventsource-v0.2.0) - 2024-03-17

### Added
- add a stronger clippy ([#31](https://github.com/horfimbor/horfimbor-engine/pull/31))
</blockquote>

## `horfimbor-eventsource-derive`
<blockquote>

## [0.1.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.2...horfimbor-eventsource-derive-v0.1.3) - 2024-03-17

### Added
- add a stronger clippy ([#31](https://github.com/horfimbor/horfimbor-engine/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).