### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.3...horfimbor-eventsource-derive-v0.1.4) - 2024-04-07
+
+### Fixed
+- properly use constant in macro ([#33](https://github.com/horfimbor/horfimbor-engine/pull/33))
+
 ## [0.1.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.2...horfimbor-eventsource-derive-v0.1.3) - 2024-03-17
 
 ### Added

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.2.0...horfimbor-eventsource-v0.2.1) - 2024-04-07
+
+### Fixed
+- properly use constant in macro ([#33](https://github.com/horfimbor/horfimbor-engine/pull/33))
+
 ## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.1.2...horfimbor-eventsource-v0.2.0) - 2024-03-17
 
 ### Added

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tokio = "1.26"
 thiserror = "1.0"
-horfimbor-eventsource-derive = { version = "0.1.3", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.4", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.25", features = ["tokio-rustls-comp"], optional = true }
 chrono = "0.4"
 


### PR DESCRIPTION
## 🤖 New release
* `horfimbor-eventsource`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `horfimbor-eventsource-derive`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource`
<blockquote>

## [0.2.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.2.0...horfimbor-eventsource-v0.2.1) - 2024-04-07

### Fixed
- properly use constant in macro ([#33](https://github.com/horfimbor/horfimbor-engine/pull/33))
</blockquote>

## `horfimbor-eventsource-derive`
<blockquote>

## [0.1.4](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.3...horfimbor-eventsource-derive-v0.1.4) - 2024-04-07

### Fixed
- properly use constant in macro ([#33](https://github.com/horfimbor/horfimbor-engine/pull/33))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).