### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.4...horfimbor-eventsource-derive-v0.1.5) - 2024-08-27
+
+### Other
+- add doc ([#45](https://github.com/horfimbor/horfimbor-engine/pull/45))
+- Add time ([#42](https://github.com/horfimbor/horfimbor-engine/pull/42))
+- allow event composition to allow the use of public events ([#37](https://github.com/horfimbor/horfimbor-engine/pull/37))
+
 ## [0.1.4](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.3...horfimbor-eventsource-derive-v0.1.4) - 2024-04-07
 
 ### Fixed

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.2.2...horfimbor-eventsource-v0.3.0) - 2024-08-27
+
+### Other
+- add doc ([#45](https://github.com/horfimbor/horfimbor-engine/pull/45))
+- Add time ([#42](https://github.com/horfimbor/horfimbor-engine/pull/42))
+- add cargo machete to CI ([#41](https://github.com/horfimbor/horfimbor-engine/pull/41))
+- move error from dto to state ([#40](https://github.com/horfimbor/horfimbor-engine/pull/40))
+- move subscription out of dto ([#39](https://github.com/horfimbor/horfimbor-engine/pull/39))
+- allow event composition to allow the use of public events ([#37](https://github.com/horfimbor/horfimbor-engine/pull/37))
+
 ## [0.2.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.2.1...horfimbor-eventsource-v0.2.2) - 2024-08-09
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { version = "1.1", features = ["v4", "serde"] }
 tokio = "1.26"
 thiserror = { workspace = true }
-horfimbor-eventsource-derive = { version = "0.1.4", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.5", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.26", features = ["tokio-rustls-comp"], optional = true }
 
 [features]

--- a/horfimbor-time/CHANGELOG.md
+++ b/horfimbor-time/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.1.0...horfimbor-time-v0.2.0) - 2024-08-27
+
+### Other
+- switch to chrono duration ([#44](https://github.com/horfimbor/horfimbor-engine/pull/44))
+- add start time to config ([#43](https://github.com/horfimbor/horfimbor-engine/pull/43))

--- a/horfimbor-time/Cargo.toml
+++ b/horfimbor-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-time"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Time calculator for the Horfimbor game"
 repository = "https://github.com/horfimbor/horfimbor-time"


### PR DESCRIPTION
## 🤖 New release
* `horfimbor-eventsource`: 0.2.2 -> 0.3.0
* `horfimbor-eventsource-derive`: 0.1.4 -> 0.1.5
* `horfimbor-time`: 0.1.0 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource`
<blockquote>

## [0.3.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.2.2...horfimbor-eventsource-v0.3.0) - 2024-08-27

### Other
- add doc ([#45](https://github.com/horfimbor/horfimbor-engine/pull/45))
- Add time ([#42](https://github.com/horfimbor/horfimbor-engine/pull/42))
- add cargo machete to CI ([#41](https://github.com/horfimbor/horfimbor-engine/pull/41))
- move error from dto to state ([#40](https://github.com/horfimbor/horfimbor-engine/pull/40))
- move subscription out of dto ([#39](https://github.com/horfimbor/horfimbor-engine/pull/39))
- allow event composition to allow the use of public events ([#37](https://github.com/horfimbor/horfimbor-engine/pull/37))
</blockquote>

## `horfimbor-eventsource-derive`
<blockquote>

## [0.1.5](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.4...horfimbor-eventsource-derive-v0.1.5) - 2024-08-27

### Other
- add doc ([#45](https://github.com/horfimbor/horfimbor-engine/pull/45))
- Add time ([#42](https://github.com/horfimbor/horfimbor-engine/pull/42))
- allow event composition to allow the use of public events ([#37](https://github.com/horfimbor/horfimbor-engine/pull/37))
</blockquote>

## `horfimbor-time`
<blockquote>

## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.1.0...horfimbor-time-v0.2.0) - 2024-08-27

### Other
- switch to chrono duration ([#44](https://github.com/horfimbor/horfimbor-engine/pull/44))
- add start time to config ([#43](https://github.com/horfimbor/horfimbor-engine/pull/43))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).