### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.5...horfimbor-eventsource-derive-v0.1.6) - 2025-02-08
+
+### Added
+
+- replace uuid_v4 by uuid_v7 and allow to create model_key with uuid_v8 (#48)
+
+### Other
+
+- *(deps)* upgrade dependencies (#50)
+
 ## [0.1.5](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.4...horfimbor-eventsource-derive-v0.1.5) - 2024-08-27
 
 ### Other

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.0...horfimbor-eventsource-v0.3.1) - 2025-02-08
+
+### Added
+
+- add helper function on ModelKey (#49)
+- replace uuid_v4 by uuid_v7 and allow to create model_key with uuid_v8 (#48)
+
+### Fixed
+
+- display of error was missing (#46)
+
+### Other
+
+- *(deps)* upgrade eventstore (#51)
+- *(deps)* upgrade dependencies (#50)
+
 ## [0.3.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.2.2...horfimbor-eventsource-v0.3.0) - 2024-08-27
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { version = "1.1", features = ["v7", "v8", "serde"] }
 tokio = "1.26"
 thiserror = { workspace = true }
-horfimbor-eventsource-derive = { version = "0.1.5", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.6", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.28", features = ["tokio-rustls-comp"], optional = true }
 sha1 = "0.10"
 

--- a/horfimbor-time/CHANGELOG.md
+++ b/horfimbor-time/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.0...horfimbor-time-v0.2.1) - 2025-02-08
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.1.0...horfimbor-time-v0.2.0) - 2024-08-27
 
 ### Other

--- a/horfimbor-time/Cargo.toml
+++ b/horfimbor-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-time"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Time calculator for the Horfimbor game"
 repository = "https://github.com/horfimbor/horfimbor-time"


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-eventsource`: 0.3.1
* `horfimbor-eventsource-derive`: 0.1.6
* `horfimbor-time`: 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource`

<blockquote>

## [0.3.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.0...horfimbor-eventsource-v0.3.1) - 2025-02-08

### Added

- add helper function on ModelKey (#49)
- replace uuid_v4 by uuid_v7 and allow to create model_key with uuid_v8 (#48)

### Fixed

- display of error was missing (#46)

### Other

- *(deps)* upgrade eventstore (#51)
- *(deps)* upgrade dependencies (#50)
</blockquote>

## `horfimbor-eventsource-derive`

<blockquote>

## [0.1.6](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.5...horfimbor-eventsource-derive-v0.1.6) - 2025-02-08

### Added

- replace uuid_v4 by uuid_v7 and allow to create model_key with uuid_v8 (#48)

### Other

- *(deps)* upgrade dependencies (#50)
</blockquote>

## `horfimbor-time`

<blockquote>

## [0.2.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.0...horfimbor-time-v0.2.1) - 2025-02-08

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).