### PR TITLE
chore: release

### DIFF
--- a/horfimbor-client-derive/CHANGELOG.md
+++ b/horfimbor-client-derive/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-client-derive-v0.1.0) - 2025-03-10
+
+### Other
+
+- add horfimbor-jwt and horfimbor-client-derive ([#57](https://github.com/horfimbor/horfimbor-engine/pull/57))

--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.6...horfimbor-eventsource-derive-v0.1.7) - 2025-03-10
+
+### Other
+
+- edition 2024 ([#55](https://github.com/horfimbor/horfimbor-engine/pull/55))
+
 ## [0.1.6](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.5...horfimbor-eventsource-derive-v0.1.6) - 2025-02-08
 
 ### Added

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.2...horfimbor-eventsource-v0.3.3) - 2025-03-10
+
+### Other
+
+- add horfimbor-jwt and horfimbor-client-derive ([#57](https://github.com/horfimbor/horfimbor-engine/pull/57))
+- edition 2024 ([#55](https://github.com/horfimbor/horfimbor-engine/pull/55))
+
 ## [0.3.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.1...horfimbor-eventsource-v0.3.2) - 2025-02-16
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { workspace = true}
 tokio = "1.26"
 thiserror = { workspace = true }
-horfimbor-eventsource-derive = { version = "0.1.6", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.7", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.29", features = ["tokio-rustls-comp"], optional = true }
 sha1 = "0.10"
 

--- a/horfimbor-jwt/CHANGELOG.md
+++ b/horfimbor-jwt/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-jwt-v0.1.0) - 2025-03-10
+
+### Other
+
+- add horfimbor-jwt and horfimbor-client-derive ([#57](https://github.com/horfimbor/horfimbor-engine/pull/57))

--- a/horfimbor-time/CHANGELOG.md
+++ b/horfimbor-time/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.1...horfimbor-time-v0.2.2) - 2025-03-10
+
+### Other
+
+- edition 2024 ([#55](https://github.com/horfimbor/horfimbor-engine/pull/55))
+
 ## [0.2.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.0...horfimbor-time-v0.2.1) - 2025-02-08
 
 ### Other

--- a/horfimbor-time/Cargo.toml
+++ b/horfimbor-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-time"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Time calculator for the Horfimbor game"
 repository = "https://github.com/horfimbor/horfimbor-time"


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-client-derive`: 0.1.0
* `horfimbor-eventsource-derive`: 0.1.6 -> 0.1.7
* `horfimbor-eventsource`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `horfimbor-jwt`: 0.1.0
* `horfimbor-time`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-client-derive`

<blockquote>

## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-client-derive-v0.1.0) - 2025-03-10

### Other

- add horfimbor-jwt and horfimbor-client-derive ([#57](https://github.com/horfimbor/horfimbor-engine/pull/57))
</blockquote>

## `horfimbor-eventsource-derive`

<blockquote>

## [0.1.7](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.6...horfimbor-eventsource-derive-v0.1.7) - 2025-03-10

### Other

- edition 2024 ([#55](https://github.com/horfimbor/horfimbor-engine/pull/55))
</blockquote>

## `horfimbor-eventsource`

<blockquote>

## [0.3.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.2...horfimbor-eventsource-v0.3.3) - 2025-03-10

### Other

- add horfimbor-jwt and horfimbor-client-derive ([#57](https://github.com/horfimbor/horfimbor-engine/pull/57))
- edition 2024 ([#55](https://github.com/horfimbor/horfimbor-engine/pull/55))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-jwt-v0.1.0) - 2025-03-10

### Other

- add horfimbor-jwt and horfimbor-client-derive ([#57](https://github.com/horfimbor/horfimbor-engine/pull/57))
</blockquote>

## `horfimbor-time`

<blockquote>

## [0.2.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.1...horfimbor-time-v0.2.2) - 2025-03-10

### Other

- edition 2024 ([#55](https://github.com/horfimbor/horfimbor-engine/pull/55))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).