### PR TITLE
chore: release

### DIFF
--- a/horfimbor-client-derive/CHANGELOG.md
+++ b/horfimbor-client-derive/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-derive-v0.1.0...horfimbor-client-derive-v0.1.1) - 2025-03-30
+
+### Fixed
+
+- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))
+
+### Other
+
+- release ([#56](https://github.com/horfimbor/horfimbor-engine/pull/56))
+
 ## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-client-derive-v0.1.0) - 2025-03-10
 
 ### Other

--- a/horfimbor-client-derive/Cargo.toml
+++ b/horfimbor-client-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-client-derive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "derive macro for yew and custom-elements"
 repository = "https://github.com/horfimbor/horfimbor-client-derive"

--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.7...horfimbor-eventsource-derive-v0.1.8) - 2025-03-30
+
+### Fixed
+
+- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))
+
 ## [0.1.7](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.6...horfimbor-eventsource-derive-v0.1.7) - 2025-03-10
 
 ### Other

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.3...horfimbor-eventsource-v0.3.4) - 2025-03-30
+
+### Fixed
+
+- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))
+
 ## [0.3.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.2...horfimbor-eventsource-v0.3.3) - 2025-03-10
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { workspace = true}
 tokio = "1.26"
 thiserror = { workspace = true }
-horfimbor-eventsource-derive = { version = "0.1.7", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.8", path = "../horfimbor-eventsource-derive" }
 redis= { version = "0.29", features = ["tokio-rustls-comp"], optional = true }
 sha1 = "0.10"
 

--- a/horfimbor-jwt/CHANGELOG.md
+++ b/horfimbor-jwt/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.0...horfimbor-jwt-v0.1.1) - 2025-03-30
+
+### Fixed
+
+- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))
+
+### Other
+
+- release ([#56](https://github.com/horfimbor/horfimbor-engine/pull/56))
+
 ## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-jwt-v0.1.0) - 2025-03-10
 
 ### Other

--- a/horfimbor-jwt/Cargo.toml
+++ b/horfimbor-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-jwt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Jwt handler for the game engine Horfimbor"
 repository = "https://github.com/horfimbor/horfimbor-jwt"
@@ -11,7 +11,7 @@ keywords = ["jwt"]
 jsonwebtoken = "9.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
-horfimbor-eventsource = { version = "0.3.3", path = "../horfimbor-eventsource" }
+horfimbor-eventsource = { version = "0.3.4", path = "../horfimbor-eventsource" }
 
 [lints]
 workspace = true


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-client-derive`: 0.1.0 -> 0.1.1
* `horfimbor-eventsource-derive`: 0.1.7 -> 0.1.8
* `horfimbor-eventsource`: 0.3.3 -> 0.3.4 (✓ API compatible changes)
* `horfimbor-jwt`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-client-derive`

<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-derive-v0.1.0...horfimbor-client-derive-v0.1.1) - 2025-03-30

### Fixed

- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))

### Other

- release ([#56](https://github.com/horfimbor/horfimbor-engine/pull/56))
</blockquote>

## `horfimbor-eventsource-derive`

<blockquote>

## [0.1.8](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.7...horfimbor-eventsource-derive-v0.1.8) - 2025-03-30

### Fixed

- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))
</blockquote>

## `horfimbor-eventsource`

<blockquote>

## [0.3.4](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.3...horfimbor-eventsource-v0.3.4) - 2025-03-30

### Fixed

- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.0...horfimbor-jwt-v0.1.1) - 2025-03-30

### Fixed

- fix cache computation ([#59](https://github.com/horfimbor/horfimbor-engine/pull/59))

### Other

- release ([#56](https://github.com/horfimbor/horfimbor-engine/pull/56))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).