### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.4...horfimbor-eventsource-v0.3.5) - 2025-07-07
+
+### Other
+
+- switch eventstore to kurrendDb ([#60](https://github.com/horfimbor/horfimbor-engine/pull/60))
+
 ## [0.3.4](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.3...horfimbor-eventsource-v0.3.4) - 2025-03-30
 
 ### Fixed

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 description = "an eventsource implementation on top of eventstore"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-jwt/CHANGELOG.md
+++ b/horfimbor-jwt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.1...horfimbor-jwt-v0.1.2) - 2025-07-07
+
+### Other
+
+- switch eventstore to kurrendDb ([#60](https://github.com/horfimbor/horfimbor-engine/pull/60))
+
 ## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.0...horfimbor-jwt-v0.1.1) - 2025-03-30
 
 ### Fixed

--- a/horfimbor-jwt/Cargo.toml
+++ b/horfimbor-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-jwt"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Jwt handler for the game engine Horfimbor"
 repository = "https://github.com/horfimbor/horfimbor-jwt"
@@ -12,7 +12,7 @@ categories = ["authentication"]
 jsonwebtoken = "9.3"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = { workspace = true }
-horfimbor-eventsource = { version = "0.3.4", path = "../horfimbor-eventsource" }
+horfimbor-eventsource = { version = "0.3.5", path = "../horfimbor-eventsource" }
 
 [lints]
 workspace = true


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-eventsource`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `horfimbor-jwt`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource`

<blockquote>

## [0.3.5](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.4...horfimbor-eventsource-v0.3.5) - 2025-07-07

### Other

- switch eventstore to kurrendDb ([#60](https://github.com/horfimbor/horfimbor-engine/pull/60))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.1...horfimbor-jwt-v0.1.2) - 2025-07-07

### Other

- switch eventstore to kurrendDb ([#60](https://github.com/horfimbor/horfimbor-engine/pull/60))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).