### PR TITLE
chore: release

### DIFF
--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.8...horfimbor-eventsource-derive-v0.1.9) - 2026-02-08
+
+### Other
+
+- Rename eventstore to KurrentDb and Update dependencies ([#69](https://github.com/horfimbor/horfimbor-engine/pull/69))
+
 ## [0.1.8](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.7...horfimbor-eventsource-derive-v0.1.8) - 2025-03-30
 
 ### Fixed

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.5...horfimbor-eventsource-v0.3.6) - 2026-02-08
+
+### Other
+
+- Rename eventstore to KurrentDb and Update dependencies ([#69](https://github.com/horfimbor/horfimbor-engine/pull/69))
+- use let else proposed by clippy ([#66](https://github.com/horfimbor/horfimbor-engine/pull/66))
+
 ## [0.3.5](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.4...horfimbor-eventsource-v0.3.5) - 2025-07-07
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 description = "an eventsource implementation on top of kurrentdb"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -17,7 +17,7 @@ serde_json = "1.0"
 uuid = { workspace = true }
 tokio = "1.49"
 thiserror = { workspace = true }
-horfimbor-eventsource-derive = { version = "0.1.8", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.9", path = "../horfimbor-eventsource-derive" }
 sha1 = "0.10"
 
 redis = { version = "1.0", features = ["tokio-rustls-comp"], optional = true }

--- a/horfimbor-jwt/CHANGELOG.md
+++ b/horfimbor-jwt/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.2...horfimbor-jwt-v0.2.0) - 2026-02-08
+
+### Other
+
+- Rename eventstore to KurrentDb and Update dependencies ([#69](https://github.com/horfimbor/horfimbor-engine/pull/69))
+- allow jwt to be parsed on frontend ([#65](https://github.com/horfimbor/horfimbor-engine/pull/65))
+
 ## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.1...horfimbor-jwt-v0.1.2) - 2025-07-07
 
 ### Other

--- a/horfimbor-jwt/Cargo.toml
+++ b/horfimbor-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-jwt"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 description = "Jwt handler for the game engine Horfimbor"
 repository = "https://github.com/horfimbor/horfimbor-jwt"
@@ -13,7 +13,7 @@ jsonwebtoken = "10.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 thiserror = { workspace = true }
-horfimbor-eventsource = { version = "0.3.5", path = "../horfimbor-eventsource", optional = true }
+horfimbor-eventsource = { version = "0.3.6", path = "../horfimbor-eventsource", optional = true }
 base64 = {version = "0.22.1", optional = true}
 
 # we dont need to generate uuid and want to be able to use this package in wasm, so we don't use the one define for the workspace

--- a/horfimbor-time/CHANGELOG.md
+++ b/horfimbor-time/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.2...horfimbor-time-v0.2.3) - 2026-02-08
+
+### Other
+
+- allow time config to be serialized to be shared ([#64](https://github.com/horfimbor/horfimbor-engine/pull/64))
+
 ## [0.2.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.1...horfimbor-time-v0.2.2) - 2025-03-10
 
 ### Other

--- a/horfimbor-time/Cargo.toml
+++ b/horfimbor-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-time"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "Time calculator for the Horfimbor game"
 repository = "https://github.com/horfimbor/horfimbor-time"


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-eventsource-derive`: 0.1.8 -> 0.1.9
* `horfimbor-eventsource`: 0.3.5 -> 0.3.6 (✓ API compatible changes)
* `horfimbor-jwt`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `horfimbor-time`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

### ⚠ `horfimbor-jwt` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ClaimError:Other in /tmp/.tmpr8P18K/horfimbor-engine/horfimbor-jwt/src/lib.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-eventsource-derive`

<blockquote>

## [0.1.9](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.8...horfimbor-eventsource-derive-v0.1.9) - 2026-02-08

### Other

- Rename eventstore to KurrentDb and Update dependencies ([#69](https://github.com/horfimbor/horfimbor-engine/pull/69))
</blockquote>

## `horfimbor-eventsource`

<blockquote>

## [0.3.6](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.5...horfimbor-eventsource-v0.3.6) - 2026-02-08

### Other

- Rename eventstore to KurrentDb and Update dependencies ([#69](https://github.com/horfimbor/horfimbor-engine/pull/69))
- use let else proposed by clippy ([#66](https://github.com/horfimbor/horfimbor-engine/pull/66))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.2.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.1.2...horfimbor-jwt-v0.2.0) - 2026-02-08

### Other

- Rename eventstore to KurrentDb and Update dependencies ([#69](https://github.com/horfimbor/horfimbor-engine/pull/69))
- allow jwt to be parsed on frontend ([#65](https://github.com/horfimbor/horfimbor-engine/pull/65))
</blockquote>

## `horfimbor-time`

<blockquote>

## [0.2.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.2...horfimbor-time-v0.2.3) - 2026-02-08

### Other

- allow time config to be serialized to be shared ([#64](https://github.com/horfimbor/horfimbor-engine/pull/64))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).