### PR TITLE
chore: release

### DIFF
--- a/horfimbor-callback-recall/CHANGELOG.md
+++ b/horfimbor-callback-recall/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-callback-recall-v0.1.0) - 2026-04-23
+
+### Other
+
+- Add callback recall ([#72](https://github.com/horfimbor/horfimbor-engine/pull/72))

--- a/horfimbor-client-derive/CHANGELOG.md
+++ b/horfimbor-client-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-derive-v0.1.2...horfimbor-client-derive-v0.1.3) - 2026-04-23
+
+### Other
+
+- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
+
 ## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-derive-v0.1.1...horfimbor-client-derive-v0.1.2) - 2026-04-16
 
 ### Other

--- a/horfimbor-client-derive/Cargo.toml
+++ b/horfimbor-client-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-client-derive"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "derive macro for yew and custom-elements"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-client/CHANGELOG.md
+++ b/horfimbor-client/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-v0.1.0...horfimbor-client-v0.1.1) - 2026-04-23
+
+### Other
+
+- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
+- release ([#70](https://github.com/horfimbor/horfimbor-engine/pull/70))
+
 ## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-client-v0.1.0) - 2026-04-16
 
 ### Other

--- a/horfimbor-client/Cargo.toml
+++ b/horfimbor-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-client"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "a web client helper for the horfimbor-engine with Yew"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource-derive/CHANGELOG.md
+++ b/horfimbor-eventsource-derive/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.9...horfimbor-eventsource-derive-v0.1.10) - 2026-04-23
+
+### Other
+
+- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
+
 ## [0.1.9](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.8...horfimbor-eventsource-derive-v0.1.9) - 2026-02-08
 
 ### Other

--- a/horfimbor-eventsource-derive/Cargo.toml
+++ b/horfimbor-eventsource-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource-derive"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "derive macro for horfimbor-eventsource"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.4.0...horfimbor-eventsource-v0.4.1) - 2026-04-23
+
+### Other
+
+- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
+
 ## [0.4.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.3.6...horfimbor-eventsource-v0.4.0) - 2026-04-16
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "an eventsource implementation on top of kurrentdb"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -18,7 +18,7 @@ serde_json = "1.0"
 uuid = { workspace = true }
 tokio = "1.49"
 thiserror = { workspace = true }
-horfimbor-eventsource-derive = { version = "0.1.9", path = "../horfimbor-eventsource-derive" }
+horfimbor-eventsource-derive = { version = "0.1.10", path = "../horfimbor-eventsource-derive" }
 sha1 = "0.11"
 
 redis = { version = "1.0", features = ["tokio-rustls-comp"], optional = true }

--- a/horfimbor-jwt/CHANGELOG.md
+++ b/horfimbor-jwt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.3.0...horfimbor-jwt-v0.3.1) - 2026-04-23
+
+### Other
+
+- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
+
 ## [0.3.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.2.0...horfimbor-jwt-v0.3.0) - 2026-04-16
 
 ### Other

--- a/horfimbor-jwt/Cargo.toml
+++ b/horfimbor-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-jwt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Jwt handler for the game engine Horfimbor"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -14,8 +14,8 @@ jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 thiserror = { workspace = true }
-horfimbor-eventsource = { version = "0.4.0", path = "../horfimbor-eventsource", optional = true }
-horfimbor-client = { version = "0.1.0", path = "../horfimbor-client", optional = true }
+horfimbor-eventsource = { version = "0.4.1", path = "../horfimbor-eventsource", optional = true }
+horfimbor-client = { version = "0.1.1", path = "../horfimbor-client", optional = true }
 base64 = {version = "0.22", optional = true}
 uuid = { workspace = true }
 rocket = {version = "0.5", optional = true}

--- a/horfimbor-time/CHANGELOG.md
+++ b/horfimbor-time/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.3.0...horfimbor-time-v0.4.0) - 2026-04-23
+
+### Other
+
+- Add callback recall ([#72](https://github.com/horfimbor/horfimbor-engine/pull/72))
+- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
+
 ## [0.3.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.2.3...horfimbor-time-v0.3.0) - 2026-04-16
 
 ### Other

--- a/horfimbor-time/Cargo.toml
+++ b/horfimbor-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-time"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Time calculator for the Horfimbor game"
 repository = "https://github.com/horfimbor/horfimbor-engine"


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-client`: 0.1.0 -> 0.1.1
* `horfimbor-client-derive`: 0.1.2 -> 0.1.3
* `horfimbor-eventsource-derive`: 0.1.9 -> 0.1.10
* `horfimbor-eventsource`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `horfimbor-jwt`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `horfimbor-time`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `horfimbor-callback-recall`: 0.1.0

### ⚠ `horfimbor-time` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  HfTime::as_millis, previously in file /tmp/.tmpJmQamj/horfimbor-time/src/lib.rs:193
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-client`

<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-v0.1.0...horfimbor-client-v0.1.1) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
- release ([#70](https://github.com/horfimbor/horfimbor-engine/pull/70))
</blockquote>

## `horfimbor-client-derive`

<blockquote>

## [0.1.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-derive-v0.1.2...horfimbor-client-derive-v0.1.3) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-eventsource-derive`

<blockquote>

## [0.1.10](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.9...horfimbor-eventsource-derive-v0.1.10) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-eventsource`

<blockquote>

## [0.4.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.4.0...horfimbor-eventsource-v0.4.1) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.3.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.3.0...horfimbor-jwt-v0.3.1) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-time`

<blockquote>

## [0.4.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.3.0...horfimbor-time-v0.4.0) - 2026-04-23

### Other

- Add callback recall ([#72](https://github.com/horfimbor/horfimbor-engine/pull/72))
- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-callback-recall`

<blockquote>

## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-callback-recall-v0.1.0) - 2026-04-23

### Other

- Add callback recall ([#72](https://github.com/horfimbor/horfimbor-engine/pull/72))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).