### PR TITLE
chore: release

### DIFF
--- a/horfimbor-callback-recall/CHANGELOG.md
+++ b/horfimbor-callback-recall/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-callback-recall-v0.1.0...horfimbor-callback-recall-v0.1.1) - 2026-05-14
+
+### Other
+
+- release ([#71](https://github.com/horfimbor/horfimbor-engine/pull/71))
+
 ## [0.1.0](https://github.com/horfimbor/horfimbor-engine/releases/tag/horfimbor-callback-recall-v0.1.0) - 2026-04-23
 
 ### Other

--- a/horfimbor-callback-recall/Cargo.toml
+++ b/horfimbor-callback-recall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-callback-recall"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "a small lib allowing to store callback that will be triggered at a specified date"
 repository = "https://github.com/horfimbor/horfimbor-engine"


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-client`: 0.1.0 -> 0.1.1
* `horfimbor-client-derive`: 0.1.2 -> 0.1.3
* `horfimbor-eventsource-derive`: 0.1.9 -> 0.1.10
* `horfimbor-eventsource`: 0.4.0 -> 0.4.1
* `horfimbor-jwt`: 0.3.0 -> 0.3.1
* `horfimbor-time`: 0.3.0 -> 0.4.0
* `horfimbor-callback-recall`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-client`

<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-v0.1.0...horfimbor-client-v0.1.1) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
- release ([#70](https://github.com/horfimbor/horfimbor-engine/pull/70))
</blockquote>

## `horfimbor-client-derive`

<blockquote>

## [0.1.3](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-derive-v0.1.2...horfimbor-client-derive-v0.1.3) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-eventsource-derive`

<blockquote>

## [0.1.10](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-derive-v0.1.9...horfimbor-eventsource-derive-v0.1.10) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-eventsource`

<blockquote>

## [0.4.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.4.0...horfimbor-eventsource-v0.4.1) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.3.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.3.0...horfimbor-jwt-v0.3.1) - 2026-04-23

### Other

- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-time`

<blockquote>

## [0.4.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-time-v0.3.0...horfimbor-time-v0.4.0) - 2026-04-23

### Other

- Add callback recall ([#72](https://github.com/horfimbor/horfimbor-engine/pull/72))
- Setup readme ([#73](https://github.com/horfimbor/horfimbor-engine/pull/73))
</blockquote>

## `horfimbor-callback-recall`

<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-callback-recall-v0.1.0...horfimbor-callback-recall-v0.1.1) - 2026-05-14

### Other

- release ([#71](https://github.com/horfimbor/horfimbor-engine/pull/71))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).