### PR TITLE
chore: release

### DIFF
--- a/horfimbor-client/CHANGELOG.md
+++ b/horfimbor-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-v0.1.1...horfimbor-client-v0.1.2) - 2026-07-01
+
+### Fixed
+
+- fix cache colision ([#76](https://github.com/horfimbor/horfimbor-engine/pull/76))
+
 ## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-v0.1.0...horfimbor-client-v0.1.1) - 2026-04-23
 
 ### Other

--- a/horfimbor-client/Cargo.toml
+++ b/horfimbor-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-client"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "a web client helper for the horfimbor-engine with Yew"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-eventsource/CHANGELOG.md
+++ b/horfimbor-eventsource/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.4.1...horfimbor-eventsource-v0.5.0) - 2026-07-01
+
+### Fixed
+
+- fix cache colision ([#76](https://github.com/horfimbor/horfimbor-engine/pull/76))
+
 ## [0.4.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.4.0...horfimbor-eventsource-v0.4.1) - 2026-04-23
 
 ### Other

--- a/horfimbor-eventsource/Cargo.toml
+++ b/horfimbor-eventsource/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-eventsource"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 description = "an eventsource implementation on top of kurrentdb"
 repository = "https://github.com/horfimbor/horfimbor-engine"

--- a/horfimbor-jwt/CHANGELOG.md
+++ b/horfimbor-jwt/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.3.1...horfimbor-jwt-v0.3.2) - 2026-07-01
+
+### Other
+
+- updated the following local packages: horfimbor-client, horfimbor-eventsource
+
 ## [0.3.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.3.0...horfimbor-jwt-v0.3.1) - 2026-04-23
 
 ### Other

--- a/horfimbor-jwt/Cargo.toml
+++ b/horfimbor-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "horfimbor-jwt"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 description = "Jwt handler for the game engine Horfimbor"
 repository = "https://github.com/horfimbor/horfimbor-engine"
@@ -14,8 +14,8 @@ jsonwebtoken = { version = "10.3", features = ["rust_crypto"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 thiserror = { workspace = true }
-horfimbor-eventsource = { version = "0.4.1", path = "../horfimbor-eventsource", optional = true }
-horfimbor-client = { version = "0.1.1", path = "../horfimbor-client", optional = true }
+horfimbor-eventsource = { version = "0.5.0", path = "../horfimbor-eventsource", optional = true }
+horfimbor-client = { version = "0.1.2", path = "../horfimbor-client", optional = true }
 base64 = {version = "0.22", optional = true}
 uuid = { workspace = true }
 rocket = {version = "0.5", optional = true}


### PR DESCRIPTION



## 🤖 New release

* `horfimbor-client`: 0.1.1 -> 0.1.2
* `horfimbor-eventsource`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `horfimbor-callback-recall`: 0.1.0 -> 0.1.1
* `horfimbor-jwt`: 0.3.1 -> 0.3.2

### ⚠ `horfimbor-eventsource` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method horfimbor_eventsource::repository::Repository::repository_kind in file /tmp/.tmpIq57Bu/horfimbor-engine/horfimbor-eventsource/src/repository.rs:148

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_missing.ron

Failed in:
  method new of trait Repository, previously in file /tmp/.tmpr5eNkW/horfimbor-eventsource/src/repository.rs:93

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-item-signature
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  CacheDb::get_from_db now takes 2 instead of 1 parameters, in file /tmp/.tmpIq57Bu/horfimbor-engine/horfimbor-eventsource/src/cache_db/mod.rs:24
  CacheDb::set_in_db now takes 3 instead of 2 parameters, in file /tmp/.tmpIq57Bu/horfimbor-engine/horfimbor-eventsource/src/cache_db/mod.rs:31
  CacheDb::get now takes 2 instead of 1 parameters, in file /tmp/.tmpIq57Bu/horfimbor-engine/horfimbor-eventsource/src/cache_db/mod.rs:39
  CacheDb::set now takes 3 instead of 2 parameters, in file /tmp/.tmpIq57Bu/horfimbor-engine/horfimbor-eventsource/src/cache_db/mod.rs:56
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `horfimbor-client`

<blockquote>

## [0.1.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-client-v0.1.1...horfimbor-client-v0.1.2) - 2026-07-01

### Fixed

- fix cache colision ([#76](https://github.com/horfimbor/horfimbor-engine/pull/76))
</blockquote>

## `horfimbor-eventsource`

<blockquote>

## [0.5.0](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-eventsource-v0.4.1...horfimbor-eventsource-v0.5.0) - 2026-07-01

### Fixed

- fix cache colision ([#76](https://github.com/horfimbor/horfimbor-engine/pull/76))
</blockquote>

## `horfimbor-callback-recall`

<blockquote>

## [0.1.1](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-callback-recall-v0.1.0...horfimbor-callback-recall-v0.1.1) - 2026-05-14

### Other

- release ([#71](https://github.com/horfimbor/horfimbor-engine/pull/71))
</blockquote>

## `horfimbor-jwt`

<blockquote>

## [0.3.2](https://github.com/horfimbor/horfimbor-engine/compare/horfimbor-jwt-v0.3.1...horfimbor-jwt-v0.3.2) - 2026-07-01

### Other

- updated the following local packages: horfimbor-client, horfimbor-eventsource
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).